### PR TITLE
Remove coverall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           key: composer-cache-{{ .Branch }}-{{ checksum "composer.json" }}
           paths:
             - "~/.composer/cache"
-      - run: composer ci
+      - run: composer test
 workflows:
   version: 2
   test:

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: tests/build/clover.xml
-json_path: tests/build/coveralls-upload.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 * text=auto
 
 /.circleci          export-ignore
-/.coveralls.yml     export-ignore
 /.editorconfig      export-ignore
 /.gitattributes     export-ignore
 /.github            export-ignore

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Laravel CSV
 [![CircleCI](https://circleci.com/gh/innovator-japan/laravel-csv/tree/master.svg?style=svg)](https://circleci.com/gh/innovator-japan/laravel-csv/tree/master)
-[![Coverage Status](https://coveralls.io/repos/github/innovator-japan/laravel-csv/badge.svg?branch=master)](https://coveralls.io/github/innovator-japan/laravel-csv?branch=master)
 [![License](https://poser.pugx.org/innovator-japan/laravel-csv/license)](https://packagist.org/packages/innovator-japan/laravel-csv)
 
 ## Features

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.7",
-        "php-coveralls/php-coveralls": "^2.1",
         "phpmd/phpmd": "^2.6",
         "phpstan/phpstan": "^0.11.1",
         "phpstan/phpstan-phpunit": "^0.11.0",
@@ -60,21 +59,11 @@
         "phpunit": [
             "./vendor/bin/phpunit --colors=always"
         ],
-        "phpunit-ci": [
-            "./vendor/bin/phpunit --colors=always --coverage-clover=tests/build/clover.xml",
-            "./vendor/bin/php-coveralls"
-        ],
         "test": [
             "@phpcs",
             "@phpmd",
             "@phpstan",
             "@phpunit"
-        ],
-        "ci": [
-            "@phpcs",
-            "@phpmd",
-            "@phpstan",
-            "@phpunit-ci"
         ]
     },
     "config": {


### PR DESCRIPTION
### Summary
- Remove coverall.io components. ( because we stopped using it. )
